### PR TITLE
Fix null array values and adds AnnotationMirror guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Why is it problematic? An annotation processor is not guaranteed to have classes
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-prisms</artifactId>
-      <version>1.0</version>
+      <version>1.1</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>

--- a/src/main/java/io/avaje/prism/internal/PrismGenerator.java
+++ b/src/main/java/io/avaje/prism/internal/PrismGenerator.java
@@ -245,7 +245,12 @@ public final class PrismGenerator extends AbstractProcessor {
     for (final PrismWriter w : writers) {
       w.writeField(indent, out);
     }
+
     final String annName = ((TypeElement) typeMirror.asElement()).getQualifiedName().toString();
+
+    out.format(
+        "%s    private static final String PRISM_ANNOTATION_TYPE = \"%s\";%n%n",
+        indent, ((TypeElement) (typeMirror.asElement())).getQualifiedName());
     out.format("%s    /**%n", indent);
     out.format("%s      * An instance of the Values inner class whose%n", indent);
     out.format(
@@ -268,9 +273,7 @@ public final class PrismGenerator extends AbstractProcessor {
       out.format("%s      * is returned.%n", indent);
       out.format("%s      */%n", indent);
       out.format("%s    %sstatic %s getInstanceOn(Element e) {%n", indent, access, name);
-      out.format(
-          "%s        AnnotationMirror m = getMirror(\"%s\",e);%n",
-          indent, ((TypeElement) (typeMirror.asElement())).getQualifiedName());
+      out.format("%s        AnnotationMirror m = getMirror(PRISM_ANNOTATION_TYPE, e);%n", indent);
       out.format("%s        if(m == null) return null;%n", indent);
       out.format("%s        return getInstance(m);%n", indent);
       out.format("%s   }%n%n", indent);
@@ -278,10 +281,11 @@ public final class PrismGenerator extends AbstractProcessor {
     out.format(
         "%s    /** Return a prism of the {@code @%s} annotation whose mirror is mirror. %n",
         indent, annName);
-    out.format("%s      */%n", indent);
+    out.format("%s      */%n%n", indent);
     out.format(
         "%s    %sstatic %s getInstance(AnnotationMirror mirror) {%n",
         indent, inner ? "private " : access, name);
+    out.format("%s        if(!PRISM_ANNOTATION_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n", indent, name);
     out.format("%s        return new %s(mirror);%n", indent, name);
     out.format("%s    }%n%n", indent);
     // write constructor
@@ -442,7 +446,7 @@ public final class PrismGenerator extends AbstractProcessor {
             + "        AnnotationValue av = memberValues.get(name);\n"
             + "        if(av == null) av = defaults.get(name);\n"
             + "        if(av == null) {\n"
-            + "            return null;\n"
+            + "            return java.util.Collections.EMPTY_LIST;\n"
             + "        }\n"
             + "        if(av.getValue() instanceof List) {\n"
             + "            List<T> result = new ArrayList<T>();\n"
@@ -450,12 +454,12 @@ public final class PrismGenerator extends AbstractProcessor {
             + "                if(clazz.isInstance(v.getValue())) {\n"
             + "                    result.add(clazz.cast(v.getValue()));\n"
             + "                } else{\n"
-            + "                    return null;\n"
+            + "                    return java.util.Collections.EMPTY_LIST;\n"
             + "                }\n"
             + "            }\n"
             + "            return result;\n"
             + "        } else {\n"
-            + "            return null;\n"
+            + "            return java.util.Collections.EMPTY_LIST;\n"
             + "        }\n"
             + "    }\n"
             + "    @SuppressWarnings(\"unchecked\")\n"

--- a/src/main/java/io/avaje/prism/internal/PrismGenerator.java
+++ b/src/main/java/io/avaje/prism/internal/PrismGenerator.java
@@ -285,7 +285,7 @@ public final class PrismGenerator extends AbstractProcessor {
     out.format(
         "%s    %sstatic %s getInstance(AnnotationMirror mirror) {%n",
         indent, inner ? "private " : access, name);
-    out.format("%s        if(!PRISM_ANNOTATION_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n", indent, name);
+    out.format("%s        if(mirror == null || !PRISM_ANNOTATION_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n", indent, name);
     out.format("%s        return new %s(mirror);%n", indent, name);
     out.format("%s    }%n%n", indent);
     // write constructor

--- a/src/test/java/io/avaje/prisms/test/TestClass.java
+++ b/src/test/java/io/avaje/prisms/test/TestClass.java
@@ -1,12 +1,20 @@
 package io.avaje.prisms.test;
 
-import io.avaje.jsonb.spi.Generated;
 import io.avaje.prism.GeneratePrism;
 
 @io.avaje.prism.GeneratePrisms({
-  @GeneratePrism(value = io.avaje.jsonb.Json.MixIn.class),
   @GeneratePrism(value = io.avaje.jsonb.Json.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Import.class),
   @GeneratePrism(value = io.avaje.jsonb.Json.JsonAlias.class),
-  @GeneratePrism(value = Generated.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Ignore.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Property.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.MixIn.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Raw.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.SubTypes.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.SubType.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Unmapped.class),
+  @GeneratePrism(value = io.avaje.jsonb.Json.Value.class),
+  @GeneratePrism(value = io.avaje.jsonb.spi.MetaData.class),
+  @GeneratePrism(value = io.avaje.jsonb.spi.MetaData.Factory.class),
 })
 public class TestClass {}


### PR DESCRIPTION
Fixes generated `getInstance` method to only accept annotation mirrors of the target prism type. Also changes the behavior of null arrays to return an empty list.