### PR TITLE
Read All Meta Annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Fork of the legendary [hickory annotation processer](https://javadoc.io/static/c
 - Generates a `getAllInstances` method to retrieve a list of prisms from an element
 - Generates an `isPresent` method to easily check if an element has the target annotation.
 - Generates `Optional` factory methods  
+- Generates a `getAllInstances` method to retrieve a list of prisms from an element
+- Generates a `getAllOnMetaAnnotations` method to retrieve a list of prisms from an element's annotations
 - Exposes the fully qualified type of the target annotation as a string.
 - `getInstance` returns null instead of throwing exceptions when the provided mirror doesn't match the prism target
 - null annotation array values are returned as empty lists
@@ -43,7 +45,7 @@ A prism has the same member methods as the annotation except that the return typ
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-prisms</artifactId>
-      <version>1.5</version>
+      <version>1.6</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>
@@ -60,7 +62,7 @@ A prism has the same member methods as the annotation except that the return typ
       <path>
           <groupId>io.avaje</groupId>
           <artifactId>avaje-prisms</artifactId>
-          <version>1.5</version>
+          <version>1.6</version>
       </path>
     </annotationProcessorPaths>
   </configuration>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 # Avaje Prisms
 
-Fork of the legendary [hickory annotation processer](https://javadoc.io/static/com.jolira/hickory/1.0.0/net/java/dev/hickory/prism/package-summary.html). Hickory has served well since it was created in 2010, but it doesn't have module support, and isn't likely to recieve it. 
+Fork of the legendary [hickory annotation processor](https://javadoc.io/static/com.jolira/hickory/1.0.0/net/java/dev/hickory/prism/package-summary.html). Hickory has served pretty well since it was created in 2010, but it's unmaintained and doesn't have module support. 
 
 ## Differences from Hickory
 
@@ -13,7 +13,7 @@ Fork of the legendary [hickory annotation processer](https://javadoc.io/static/c
 - Adds modular support via module-info
 - `@GeneratedPrism` is now repeatable
 - Generates a `getAllInstances` method to retrieve a list of prisms from an element
-- Generates an `isPresent` method to easily check if an element has the target annotation.
+- Generates an `isPresent` method to easily check if an element has the target annotation
 - Generates `Optional` factory methods  
 - Generates a `getAllInstances` method to retrieve a list of prisms from an element
 - Generates a `getAllOnMetaAnnotations` method to retrieve a list of prisms from an element's annotations
@@ -86,7 +86,7 @@ MyExampleAnnotationPrism exampleAnnotation = MyExampleAnnotationPrism.getInstanc
 //can get the original annotation type as a string
 String annotationQualifiedType = MyExampleAnnotationPrism.PRISM_TYPE
 
-//can call the annotation methods as if the annotation was practically present on the classpath.
+//can easily retrive the annotation values as if the annotation was present on the classpath.
 exampleAnnotation.getValue()
   ...
     }

--- a/avaje-prisms/pom.xml
+++ b/avaje-prisms/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.avaje</groupId>
 		<artifactId>avaje-prisms-parent</artifactId>
-		<version>1.4</version>
+		<version>1.6</version>
 	</parent>
 	<groupId>io.avaje</groupId>
 	<artifactId>avaje-prisms</artifactId>

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
@@ -60,7 +60,7 @@ public class FactoryMethodWriter {
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
     out.format("%s    %sstatic %s getInstanceOn(Element element) {%n", indent, access, name);
-    out.format("%s        AnnotationMirror mirror = getMirror(PRISM_TYPE, element);%n", indent);
+    out.format("%s        AnnotationMirror mirror = getMirror(element);%n", indent);
     out.format("%s        if(mirror == null) return null;%n", indent);
     out.format("%s        return getInstance(mirror);%n", indent);
     out.format("%s   }%n%n", indent);
@@ -75,7 +75,7 @@ public class FactoryMethodWriter {
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
     out.format("%s    %sstatic Optional<%s> getOptionalOn(Element element) {%n", indent, access, name);
-    out.format("%s        AnnotationMirror mirror = getMirror(PRISM_TYPE, element);%n", indent);
+    out.format("%s        AnnotationMirror mirror = getMirror(element);%n", indent);
     out.format("%s        if(mirror == null) return Optional.empty();%n", indent);
     out.format("%s        return getOptional(mirror);%n", indent);
     out.format("%s   }%n%n", indent);
@@ -107,7 +107,7 @@ public class FactoryMethodWriter {
     out.format("%s                e ->%n", indent);
     out.format("%s                    Stream.concat(%n", indent);
     out.format("%s                        getAllOnMetaAnnotations(e, seen),%n", indent);
-    out.format("%s                        getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance)));%n", indent, name);
+    out.format("%s                        getMirrors(element).map(%s::getInstance)));%n", indent, name);
     out.format("%s   }%n%n", indent);
   }
 
@@ -119,7 +119,9 @@ public class FactoryMethodWriter {
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
     out.format("%s    %sstatic List<%s> getAllInstancesOn(Element element) {%n", indent, access, name);
-    out.format("%s        return getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance).collect(toList());%n", indent, name);
+    out.format("%s        return getMirrors(element)%n", indent);
+    out.format("%s            .map(%s::getInstance)%n", indent, name);
+    out.format("%s            .collect(toList());%n", indent);
     out.format("%s   }%n%n", indent);
   }
 

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
@@ -46,9 +46,7 @@ public class FactoryMethodWriter {
 
   private void writeIsPresent() {
     // Is Present
-    out.format(
-        "%s    /** Returns true if the prism annotation is present on the element, else false. */%n",
-        indent);
+    out.format("%s    /** Returns true if the prism annotation is present on the element, else false. */%n", indent);
     out.format("%s    %sstatic boolean isPresent(Element element) {%n", indent, access);
     out.format("%s        return getInstanceOn(element) != null;%n", indent);
     out.format("%s   }%n%n", indent);
@@ -56,15 +54,9 @@ public class FactoryMethodWriter {
 
   private void writeGetInstanceOn() {
     // get single instance
-    out.format(
-        "%s    /** Return a prism representing the {@code @%s} annotation on 'e'. %n",
-        indent, annName);
-    out.format(
-        "%s      * similar to {@code element.getAnnotation(%s.class)} except that %n",
-        indent, annName);
-    out.format(
-        "%s      * an instance of this class rather than an instance of {@code %s}%n",
-        indent, annName);
+    out.format("%s    /** Return a prism representing the {@code @%s} annotation on 'e'. %n", indent, annName);
+    out.format("%s      * similar to {@code element.getAnnotation(%s.class)} except that %n", indent, annName);
+    out.format("%s      * an instance of this class rather than an instance of {@code %s}%n", indent, annName);
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
     out.format("%s    %sstatic %s getInstanceOn(Element element) {%n", indent, access, name);
@@ -77,19 +69,12 @@ public class FactoryMethodWriter {
   void writeGetOptionalOn() {
 
     // getOptionalOn
-    out.format(
-        "%s    /** Return a Optional representing a nullable {@code @%s} annotation on 'e'. %n",
-        indent, annName);
-    out.format(
-        "%s      * similar to {@code element.getAnnotation(%s.class)} except that %n",
-        indent, annName);
-    out.format(
-        "%s      * an Optional of this class rather than an instance of {@code %s}%n",
-        indent, annName);
+    out.format("%s    /** Return a Optional representing a nullable {@code @%s} annotation on 'e'. %n", indent, annName);
+    out.format("%s      * similar to {@code element.getAnnotation(%s.class)} except that %n", indent, annName);
+    out.format("%s      * an Optional of this class rather than an instance of {@code %s}%n", indent, annName);
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
-    out.format(
-        "%s    %sstatic Optional<%s> getOptionalOn(Element element) {%n", indent, access, name);
+    out.format("%s    %sstatic Optional<%s> getOptionalOn(Element element) {%n", indent, access, name);
     out.format("%s        AnnotationMirror mirror = getMirror(PRISM_TYPE, element);%n", indent);
     out.format("%s        if(mirror == null) return Optional.empty();%n", indent);
     out.format("%s        return getOptional(mirror);%n", indent);
@@ -103,55 +88,46 @@ public class FactoryMethodWriter {
     out.format("%s      */%n", indent);
     out.format("%s    %sstatic List<%s> getAllOnMetaAnnotations(Element element) {%n",indent, access, name);
     out.format("%s        if (element == null || element.getAnnotationMirrors().isEmpty()) return List.of();%n%n",indent);
-    out.format("%s        return getAllOnMetaAnnotations(element, new HashSet<>());%n", indent);
+    out.format("%s        //use a hashset to keep track of seen annotations %n", indent);
+    out.format("%s        return getAllOnMetaAnnotations(element, new HashSet<>()).collect(toList());%n", indent);
     out.format("%s   }%n%n", indent);
-    //this will prevent a recursive loop
-    out.format("%s    private static List<%s> getAllOnMetaAnnotations(Element element, Set<String> seen) {%n",indent, name);
-    out.format("%s          if (element == null || element.getAnnotationMirrors().isEmpty()) return List.of();%n%n",indent);
+
+
+    out.format("%s    /** Recursively search annotations elements for prisms.%n", indent);
+    out.format("%s      * Uses a set to keep track of known annotations to avoid repeats/recursive loop. %n",indent);
+    out.format("%s      */%n", indent);
+    out.format("%s    private static Stream<%s> getAllOnMetaAnnotations(Element element, Set<String> seen) {%n",indent, name);
+    out.format("%s          if (element == null || element.getAnnotationMirrors().isEmpty()) return Stream.of();%n%n",indent);
     out.format("%s        return element.getAnnotationMirrors().stream()%n", indent);
     out.format("%s            .map(AnnotationMirror::getAnnotationType)%n", indent);
+    out.format("%s            //only search annotations %n", indent);
     out.format("%s            .filter(t -> seen.add(t.toString()))%n", indent);
     out.format("%s            .map(DeclaredType::asElement)%n", indent);
     out.format("%s            .flatMap(%n", indent);
     out.format("%s                e ->%n", indent);
     out.format("%s                    Stream.concat(%n", indent);
-    out.format("%s                        getAllOnMetaAnnotations(e, seen).stream(),%n", indent);
-    out.format("%s                        getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance)))%n",indent, name);
-    out.format("%s            .collect(toList());%n", indent);
+    out.format("%s                        getAllOnMetaAnnotations(e, seen),%n", indent);
+    out.format("%s                        getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance)));%n", indent, name);
     out.format("%s   }%n%n", indent);
   }
 
   private void writeGetAllInstances() {
     // get multiple instances
-    out.format(
-        "%s    /** Return a list of prisms representing the {@code @%s} annotation on 'e'. %n",
-        indent, annName);
-    out.format(
-        "%s      * similar to {@code e.getAnnotationsByType(%s.class)} except that %n",
-        indent, annName);
-    out.format(
-        "%s      * instances of this class rather than instances of {@code %s}%n", indent, annName);
+    out.format("%s    /** Return a list of prisms representing the {@code @%s} annotation on 'e'. %n",indent, annName);
+    out.format("%s      * similar to {@code e.getAnnotationsByType(%s.class)} except that %n", indent, annName);
+    out.format("%s      * instances of this class rather than instances of {@code %s}%n", indent, annName);
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
-    out.format(
-        "%s    %sstatic List<%s> getAllInstancesOn(Element element) {%n", indent, access, name);
-    out.format(
-        "%s        return getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance).collect(toList());%n",
-        indent, name);
+    out.format("%s    %sstatic List<%s> getAllInstancesOn(Element element) {%n", indent, access, name);
+    out.format("%s        return getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance).collect(toList());%n", indent, name);
     out.format("%s   }%n%n", indent);
   }
 
   private void writeGetInstance() {
-    out.format(
-        "%s    /** Return a prism of the {@code @%s} annotation whose mirror is mirror. %n",
-        indent, annName);
+    out.format("%s    /** Return a prism of the {@code @%s} annotation whose mirror is mirror. %n", indent, annName);
     out.format("%s      */%n", indent);
-    out.format(
-        "%s    %sstatic %s getInstance(AnnotationMirror mirror) {%n",
-        indent, inner ? "private " : access, name);
-    out.format(
-        "%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n",
-        indent);
+    out.format("%s    %sstatic %s getInstance(AnnotationMirror mirror) {%n", indent, inner ? "private " : access, name);
+    out.format("%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n", indent);
     out.format("%s        return new %s(mirror);%n", indent, name);
     out.format("%s    }%n%n", indent);
   }
@@ -159,22 +135,13 @@ public class FactoryMethodWriter {
   private void writeGetOptional() {
 
     // getOptional
-    out.format(
-        "%s    /** Return a {@code Optional<%s>} representing a {@code @%s} annotation mirror. %n",
-        indent, name, annName);
-    out.format(
-        "%s      * similar to {@code e.getAnnotation(%s.class)} except that %n", indent, annName);
-    out.format(
-        "%s      * an Optional of this class rather than an instance of {@code %s}%n",
-        indent, annName);
+    out.format("%s    /** Return a {@code Optional<%s>} representing a {@code @%s} annotation mirror. %n", indent, name, annName);
+    out.format("%s      * similar to {@code e.getAnnotation(%s.class)} except that %n", indent, annName);
+    out.format("%s      * an Optional of this class rather than an instance of {@code %s}%n", indent, annName);
     out.format("%s      * is returned.%n", indent);
     out.format("%s      */%n", indent);
-    out.format(
-        "%s    %sstatic Optional<%s> getOptional(AnnotationMirror mirror) {%n",
-        indent, inner ? "private " : access, name);
-    out.format(
-        "%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return Optional.empty();%n%n",
-        indent);
+    out.format("%s    %sstatic Optional<%s> getOptional(AnnotationMirror mirror) {%n", indent, inner ? "private " : access, name);
+    out.format("%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return Optional.empty();%n%n", indent);
     out.format("%s        return Optional.of(new %s(mirror));%n", indent, name);
     out.format("%s    }%n%n", indent);
   }

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/FactoryMethodWriter.java
@@ -1,0 +1,157 @@
+package io.avaje.prism.internal;
+
+import static io.avaje.prism.internal.ProcessingContext.asElement;
+
+import java.io.PrintWriter;
+
+import javax.lang.model.type.DeclaredType;
+
+public class FactoryMethodWriter {
+  private final String indent;
+  private final PrintWriter out;
+  private final String name;
+  private final DeclaredType typeMirror;
+  private final String access;
+  private final String annName;
+  private final boolean inner;
+  private final boolean repeatable;
+  private final boolean meta;
+
+  FactoryMethodWriter(GenerateContext ctx, boolean inner) {
+    this.indent = ctx.indent();
+    this.out = ctx.out();
+    this.name = ctx.name();
+    this.typeMirror = ctx.typeMirror();
+    this.access = ctx.access();
+    this.annName = ctx.annName();
+    this.inner = inner;
+    this.repeatable = RepeatablePrism.isPresent(asElement(typeMirror));
+
+    final var target = TargetPrism.getInstanceOn(asElement(typeMirror));
+
+    this.meta = target == null || target.value().contains("ANNOTATION_TYPE");
+  }
+
+  void write() {
+    if (!inner) {
+      writeIsPresent();
+      writeGetInstanceOn();
+      writeGetOptionalOn();
+      if (repeatable) {
+        writeGetAllInstances();
+      }
+    }
+    writeGetInstance();
+    writeGetOptional();
+  }
+
+  private void writeIsPresent() {
+    // Is Present
+    out.format(
+        "%s    /** Returns true if the prism annotation is present on the element, else false. */%n",
+        indent);
+    out.format("%s    %sstatic boolean isPresent(Element element) {%n", indent, access);
+    out.format("%s        return getInstanceOn(element) != null;%n", indent);
+    out.format("%s   }%n%n", indent);
+  }
+
+  private void writeGetInstanceOn() {
+    // get single instance
+    out.format(
+        "%s    /** Return a prism representing the {@code @%s} annotation on 'e'. %n",
+        indent, annName);
+    out.format(
+        "%s      * similar to {@code element.getAnnotation(%s.class)} except that %n",
+        indent, annName);
+    out.format(
+        "%s      * an instance of this class rather than an instance of {@code %s}%n",
+        indent, annName);
+    out.format("%s      * is returned.%n", indent);
+    out.format("%s      */%n", indent);
+    out.format("%s    %sstatic %s getInstanceOn(Element element) {%n", indent, access, name);
+    out.format("%s        AnnotationMirror mirror = getMirror(PRISM_TYPE, element);%n", indent);
+    out.format("%s        if(mirror == null) return null;%n", indent);
+    out.format("%s        return getInstance(mirror);%n", indent);
+    out.format("%s   }%n%n", indent);
+  }
+
+  void writeGetOptionalOn() {
+
+    // getOptionalOn
+    out.format(
+        "%s    /** Return a Optional representing a nullable {@code @%s} annotation on 'e'. %n",
+        indent, annName);
+    out.format(
+        "%s      * similar to {@code element.getAnnotation(%s.class)} except that %n",
+        indent, annName);
+    out.format(
+        "%s      * an Optional of this class rather than an instance of {@code %s}%n",
+        indent, annName);
+    out.format("%s      * is returned.%n", indent);
+    out.format("%s      */%n", indent);
+    out.format(
+        "%s    %sstatic Optional<%s> getOptionalOn(Element element) {%n", indent, access, name);
+    out.format("%s        AnnotationMirror mirror = getMirror(PRISM_TYPE, element);%n", indent);
+    out.format("%s        if(mirror == null) return Optional.empty();%n", indent);
+    out.format("%s        return getOptional(mirror);%n", indent);
+    out.format("%s   }%n%n", indent);
+  }
+
+  private void writeGetAllInstances() {
+    // get multiple instances
+    out.format(
+        "%s    /** Return a list of prisms representing the {@code @%s} annotation on 'e'. %n",
+        indent, annName);
+    out.format(
+        "%s      * similar to {@code e.getAnnotationsByType(%s.class)} except that %n",
+        indent, annName);
+    out.format(
+        "%s      * instances of this class rather than instances of {@code %s}%n", indent, annName);
+    out.format("%s      * is returned.%n", indent);
+    out.format("%s      */%n", indent);
+    out.format(
+        "%s    %sstatic List<%s> getAllInstancesOn(Element element) {%n", indent, access, name);
+    out.format(
+        "%s        return getMirrors(PRISM_TYPE, element).stream().map(%s::getInstance).collect(toList());%n",
+        indent, name);
+    out.format("%s   }%n%n", indent);
+  }
+
+  private void writeGetInstance() {
+    out.format(
+        "%s    /** Return a prism of the {@code @%s} annotation whose mirror is mirror. %n",
+        indent, annName);
+    out.format("%s      */%n", indent);
+    out.format(
+        "%s    %sstatic %s getInstance(AnnotationMirror mirror) {%n",
+        indent, inner ? "private " : access, name);
+    out.format(
+        "%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return null;%n%n",
+        indent);
+    out.format("%s        return new %s(mirror);%n", indent, name);
+    out.format("%s    }%n%n", indent);
+  }
+
+  private void writeGetOptional() {
+
+    // getOptional
+    out.format(
+        "%s    /** Return a {@code Optional<%s>} representing a {@code @%s} annotation mirror. %n",
+        indent, name, annName);
+    out.format(
+        "%s      * similar to {@code e.getAnnotation(%s.class)} except that %n", indent, annName);
+    out.format(
+        "%s      * an Optional of this class rather than an instance of {@code %s}%n",
+        indent, annName);
+    out.format("%s      * is returned.%n", indent);
+    out.format("%s      */%n", indent);
+    out.format(
+        "%s    %sstatic Optional<%s> getOptional(AnnotationMirror mirror) {%n",
+        indent, inner ? "private " : access, name);
+    out.format(
+        "%s        if(mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return Optional.empty();%n%n",
+        indent);
+    out.format("%s        return Optional.of(new %s(mirror));%n", indent, name);
+    out.format("%s    }%n%n", indent);
+  }
+}

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/GenerateContext.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/GenerateContext.java
@@ -1,0 +1,63 @@
+package io.avaje.prism.internal;
+
+import java.io.PrintWriter;
+
+import javax.lang.model.type.DeclaredType;
+
+public class GenerateContext {
+
+  private final String indent;
+  private final PrintWriter out;
+  private final String outerName;
+  private final String name;
+  private final DeclaredType typeMirror;
+  private final String access;
+  private String annName;
+
+  public GenerateContext(
+      String indent,
+      PrintWriter out,
+      String outerName,
+      String name,
+      DeclaredType typeMirror,
+      String access) {
+    this.indent = indent;
+    this.out = out;
+    this.outerName = outerName;
+    this.name = name;
+    this.typeMirror = typeMirror;
+    this.access = access;
+  }
+
+  public String indent() {
+    return indent;
+  }
+
+  public PrintWriter out() {
+    return out;
+  }
+
+  public String outerName() {
+    return outerName;
+  }
+
+  public String name() {
+    return name;
+  }
+
+  public String annName() {
+    return annName;
+  }
+
+  public DeclaredType typeMirror() {
+    return typeMirror;
+  }
+
+  public String access() {
+    return access;
+  }
+
+  public void setAnnName(String annName) {
+    this.annName = annName;
+  }
+}

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/GeneratePrismPrism.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/GeneratePrismPrism.java
@@ -30,9 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 package io.avaje.prism.internal;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -180,12 +178,6 @@ class GeneratePrismPrism {
     return result;
   }
 
-  private <T> List<T> getArrayValues(String name, final Class<T> clazz) {
-    final List<T> result = GeneratePrismPrism.getArrayValues(memberValues, defaults, name, clazz);
-    if (result == null) valid = false;
-    return result;
-  }
-
   private static AnnotationMirror getMirror(String fqn, Element target) {
     for (final AnnotationMirror m : target.getAnnotationMirrors()) {
       final CharSequence mfqn =
@@ -207,35 +199,5 @@ class GeneratePrismPrism {
     }
     if (clazz.isInstance(av.getValue())) return clazz.cast(av.getValue());
     return null;
-  }
-
-  private static <T> List<T> getArrayValues(
-      Map<String, AnnotationValue> memberValues,
-      Map<String, AnnotationValue> defaults,
-      String name,
-      final Class<T> clazz) {
-    AnnotationValue av = memberValues.get(name);
-    if (av == null) av = defaults.get(name);
-    if (av == null) {
-      return null;
-    }
-    if (av.getValue() instanceof List) {
-      final List<T> result = new ArrayList<>();
-      for (final AnnotationValue v : getValueAsList(av)) {
-        if (clazz.isInstance(v.getValue())) {
-          result.add(clazz.cast(v.getValue()));
-        } else {
-          return null;
-        }
-      }
-      return result;
-    } else {
-      return null;
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static List<AnnotationValue> getValueAsList(AnnotationValue av) {
-    return (List<AnnotationValue>) av.getValue();
   }
 }

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/GeneratePrismsPrism.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/GeneratePrismsPrism.java
@@ -136,12 +136,6 @@ class GeneratePrismsPrism {
   private final Map<String, AnnotationValue> memberValues = new HashMap<>(10);
   private boolean valid = true;
 
-  private <T> T getValue(String name, Class<T> clazz) {
-    final T result = GeneratePrismsPrism.getValue(memberValues, defaults, name, clazz);
-    if (result == null) valid = false;
-    return result;
-  }
-
   private <T> List<T> getArrayValues(String name, final Class<T> clazz) {
     final List<T> result = GeneratePrismsPrism.getArrayValues(memberValues, defaults, name, clazz);
     if (result == null) valid = false;
@@ -154,20 +148,6 @@ class GeneratePrismsPrism {
           ((TypeElement) m.getAnnotationType().asElement()).getQualifiedName();
       if (fqn.contentEquals(mfqn)) return m;
     }
-    return null;
-  }
-
-  private static <T> T getValue(
-      Map<String, AnnotationValue> memberValues,
-      Map<String, AnnotationValue> defaults,
-      String name,
-      Class<T> clazz) {
-    AnnotationValue av = memberValues.get(name);
-    if (av == null) av = defaults.get(name);
-    if (av == null) {
-      return null;
-    }
-    if (clazz.isInstance(av.getValue())) return clazz.cast(av.getValue());
     return null;
   }
 

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/PrismGenerator.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/PrismGenerator.java
@@ -202,7 +202,8 @@ public final class PrismGenerator extends AbstractProcessor {
         out.format("package %s;%n%n", packageName);
       }
       final var isMeta = Util.isMeta(typeMirror);
-      if (Util.isRepeatable(typeMirror) || isMeta) {
+      final var isRepeatable = Util.isRepeatable(typeMirror);
+      if (isRepeatable || isMeta) {
         out.format("import static java.util.stream.Collectors.*;%n");
         out.format("import java.util.stream.Stream;%n");
       }
@@ -243,7 +244,7 @@ public final class PrismGenerator extends AbstractProcessor {
             new GenerateContext("    ", out, name, innerName, next, access), otherPrisms);
         out.format("    }%n");
       }
-      generateStaticMembers(out, Util.isMeta(typeMirror) || Util.isRepeatable(typeMirror));
+      generateStaticMembers(out, isRepeatable || isMeta);
       out.format("}%n");
     } finally {
       out.close();

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/ProcessingContext.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/ProcessingContext.java
@@ -1,0 +1,75 @@
+package io.avaje.prism.internal;
+
+import java.io.IOException;
+
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+
+final class ProcessingContext {
+
+  private ProcessingContext() {}
+
+  private static Messager messager;
+  private static Filer filer;
+  private static Elements elementUtils;
+  private static Types typeUtils;
+
+  static void init(ProcessingEnvironment processingEnv) {
+
+    messager = processingEnv.getMessager();
+    filer = processingEnv.getFiler();
+    elementUtils = processingEnv.getElementUtils();
+    typeUtils = processingEnv.getTypeUtils();
+  }
+
+  /** Log an error message. */
+  static void logError(Element e, String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args), e);
+  }
+
+  static void logError(String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.ERROR, String.format(msg, args));
+  }
+
+  static void logWarn(String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.WARNING, String.format(msg, args));
+  }
+
+  static void logDebug(String msg, Object... args) {
+    messager.printMessage(Diagnostic.Kind.NOTE, String.format(msg, args));
+  }
+
+  /** Create a file writer for the given class name. */
+  static JavaFileObject createWriter(String cls) throws IOException {
+    return filer.createSourceFile(cls);
+  }
+
+  static TypeElement element(String rawType) {
+    return elementUtils.getTypeElement(rawType);
+  }
+
+  static Types types() {
+    return typeUtils;
+  }
+
+  static TypeElement elementMaybe(String rawType) {
+    if (rawType == null) {
+      return null;
+    } else {
+      return elementUtils.getTypeElement(rawType);
+    }
+  }
+
+  static Element asElement(TypeMirror returnType) {
+
+    return typeUtils.asElement(returnType);
+  }
+}

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/TargetPrism.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/TargetPrism.java
@@ -1,0 +1,157 @@
+package io.avaje.prism.internal;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.ElementFilter;
+
+/** A Prism representing an {@code @java.lang.annotation.Target} annotation. */
+class TargetPrism {
+  /** store prism value of value */
+  private final List<String> _value;
+
+  public static final String PRISM_TYPE = "java.lang.annotation.Target";
+
+  /**
+   * An instance of the Values inner class whose methods return the AnnotationValues used to build
+   * this prism. Primarily intended to support using Messager.
+   */
+  final Values values;
+
+  /**
+   * Return a prism representing the {@code @java.lang.annotation.Target} annotation on 'e'. similar
+   * to {@code element.getAnnotation(java.lang.annotation.Target.class)} except that an instance of
+   * this class rather than an instance of {@code java.lang.annotation.Target} is returned.
+   */
+  static TargetPrism getInstanceOn(Element element) {
+    final var mirror = getMirror(PRISM_TYPE, element);
+    if (mirror == null) return null;
+    return getInstance(mirror);
+  }
+
+  /**
+   * Return a prism of the {@code @java.lang.annotation.Target} annotation whose mirror is mirror.
+   */
+  static TargetPrism getInstance(AnnotationMirror mirror) {
+    if (mirror == null || !PRISM_TYPE.equals(mirror.getAnnotationType().toString())) return null;
+
+    return new TargetPrism(mirror);
+  }
+
+  private TargetPrism(AnnotationMirror mirror) {
+    for (final ExecutableElement key : mirror.getElementValues().keySet()) {
+      memberValues.put(key.getSimpleName().toString(), mirror.getElementValues().get(key));
+    }
+    for (final ExecutableElement member :
+        ElementFilter.methodsIn(mirror.getAnnotationType().asElement().getEnclosedElements())) {
+      defaults.put(member.getSimpleName().toString(), member.getDefaultValue());
+    }
+    final List<VariableElement> valueMirrors = getArrayValues("value", VariableElement.class);
+    _value = new ArrayList<>(valueMirrors.size());
+    for (final VariableElement valueMirror : valueMirrors) {
+      _value.add(valueMirror.getSimpleName().toString());
+    }
+    this.values = new Values(memberValues);
+    this.mirror = mirror;
+    this.isValid = valid;
+  }
+
+  /**
+   * Returns a List<String> representing the value of the {@code value()} member of the Annotation.
+   *
+   * @see java.lang.annotation.Target#value()
+   */
+  List<String> value() {
+    return _value;
+  }
+
+  /**
+   * Determine whether the underlying AnnotationMirror has no errors. True if the underlying
+   * AnnotationMirror has no errors. When true is returned, none of the methods will return null.
+   * When false is returned, a least one member will either return null, or another prism that is
+   * not valid.
+   */
+  final boolean isValid;
+
+  /**
+   * The underlying AnnotationMirror of the annotation represented by this Prism. Primarily intended
+   * to support using Messager.
+   */
+  final AnnotationMirror mirror;
+  /**
+   * A class whose members corespond to those of java.lang.annotation.Target but which each return
+   * the AnnotationValue corresponding to that member in the model of the annotations. Returns null
+   * for defaulted members. Used for Messager, so default values are not useful.
+   */
+  static class Values {
+    private final Map<String, AnnotationValue> values;
+
+    private Values(Map<String, AnnotationValue> values) {
+      this.values = values;
+    }
+    /**
+     * Return the AnnotationValue corresponding to the value() member of the annotation, or null
+     * when the default value is implied.
+     */
+    AnnotationValue value() {
+      return values.get("value");
+    }
+  }
+
+  private final Map<String, AnnotationValue> defaults = new HashMap<>(10);
+  private final Map<String, AnnotationValue> memberValues = new HashMap<>(10);
+  private boolean valid = true;
+
+  private <T> List<T> getArrayValues(String name, final Class<T> clazz) {
+    final List<T> result = TargetPrism.getArrayValues(memberValues, defaults, name, clazz);
+    if (result == null) valid = false;
+    return result;
+  }
+
+  private static AnnotationMirror getMirror(String fqn, Element target) {
+    for (final AnnotationMirror m : target.getAnnotationMirrors()) {
+      final CharSequence mfqn =
+          ((TypeElement) m.getAnnotationType().asElement()).getQualifiedName();
+      if (fqn.contentEquals(mfqn)) return m;
+    }
+    return null;
+  }
+
+  private static <T> List<T> getArrayValues(
+      Map<String, AnnotationValue> memberValues,
+      Map<String, AnnotationValue> defaults,
+      String name,
+      final Class<T> clazz) {
+    var av = memberValues.get(name);
+    if (av == null) av = defaults.get(name);
+    if (av == null) {
+      return java.util.List.of();
+    }
+    if (av.getValue() instanceof List) {
+      final List<T> result = new ArrayList<>();
+      for (final AnnotationValue v : getValueAsList(av)) {
+        if (clazz.isInstance(v.getValue())) {
+          result.add(clazz.cast(v.getValue()));
+        } else {
+          return List.of();
+        }
+      }
+      return result;
+    } else {
+      return List.of();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<AnnotationValue> getValueAsList(AnnotationValue av) {
+    return (List<AnnotationValue>) av.getValue();
+  }
+}

--- a/avaje-prisms/src/main/java/io/avaje/prism/internal/Util.java
+++ b/avaje-prisms/src/main/java/io/avaje/prism/internal/Util.java
@@ -1,0 +1,18 @@
+package io.avaje.prism.internal;
+
+import static io.avaje.prism.internal.ProcessingContext.asElement;
+
+import javax.lang.model.type.TypeMirror;
+
+class Util {
+  private Util() {}
+
+  static boolean isRepeatable(TypeMirror typeMirror) {
+    return RepeatablePrism.isPresent(asElement(typeMirror));
+  }
+
+  static boolean isMeta(TypeMirror typeMirror) {
+    final var target = TargetPrism.getInstanceOn(asElement(typeMirror));
+    return target == null || target.value().contains("ANNOTATION_TYPE");
+  }
+}

--- a/blackbox-test-prism/pom.xml
+++ b/blackbox-test-prism/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-prisms-parent</artifactId>
-    <version>1.4</version>
+    <version>1.6</version>
   </parent>
 
   <artifactId>blackbox-test-prism</artifactId>
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>io.avaje</groupId>
 			<artifactId>avaje-jsonb</artifactId>
-			<version>1.2-RC2</version>
+			<version>1.3</version>
 		</dependency>
 		<dependency>
 			<groupId>jakarta.inject</groupId>

--- a/blackbox-test-prism/src/main/java/io/avaje/prisms/TestClass.java
+++ b/blackbox-test-prism/src/main/java/io/avaje/prisms/TestClass.java
@@ -1,5 +1,7 @@
 package io.avaje.prisms;
 
+import java.lang.annotation.Target;
+
 import io.avaje.prism.GeneratePrism;
 import io.avaje.prism.GeneratePrisms;
 
@@ -23,4 +25,5 @@ import io.avaje.prism.GeneratePrisms;
 @GeneratePrism(value = io.swagger.v3.oas.annotations.OpenAPIDefinition.class, publicAccess = true)
 @GeneratePrism(value = io.swagger.v3.oas.annotations.info.Info.class, name = "INfoefPrism")
 @GeneratePrism(io.avaje.jsonb.spi.MetaData.Factory.class)
+@GeneratePrism(Target.class)
 public class TestClass {}

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<groupId>io.avaje</groupId>
 	<artifactId>avaje-prisms-parent</artifactId>
-	<version>1.4</version>
+	<version>1.6</version>
 	<packaging>pom</packaging>
 	<name>avaje-prisms-parent</name>
 	<description>A modular fork of hickory</description>


### PR DESCRIPTION
Say you have a setup like this:

```
@RequiresBean(Bird.class)
@RequiresProperty(value = "watcher", equalTo = "bird")
public @interface RequiresBirdWatcher {}
```

```
@RequiresBirdWatcher
@RequiresProperty(value = "whale.whale.whale", equalTo = "what do we have here")
public @interface RequiresWatcherAndWhale {}
```

```
@Singleton
@RequiresWatcherAndWhale
public class OtherClass {
...
}
```
You have an `OtherClass` TypeElement and want to know the values of the `@RequiresBean` prism from the the`RequiresBirdWatcher` meta-annotation that's on the `RequiresWatcherAndWhale` meta-annotation. To do this, I've added a newly generated method for meta-annotation prisms to retrieve all the prisms from the element's annotation and those annotations' annotations. 

- moved the factory writing to its own class
- now generates a `getAllOnMetaAnnotations` method that recursively reads an element's annotations to find prisms.
- now uses PRISM_TYPE directly in the getMirror Methods
- refactor `getMirrors` to use stream.
- Will only generate GetValue static methods if the target annotation has any methods
- Will only generate GetArrayValue static methods if the target annotation has any methods that return an array