### PR TITLE
Validate Module-Info

### DIFF
--- a/prism-core/src/main/java/io/avaje/prism/internal/PrismGenerator.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/PrismGenerator.java
@@ -125,6 +125,9 @@ public final class PrismGenerator extends AbstractProcessor {
       ProcessingContext.clear();
       return true;
     }
+
+    ProcessingContext.setProjectModuleElement(tes, renv);
+
     tes.stream()
         .map(renv::getElementsAnnotatedWith)
         .map(ElementFilter::typesIn)

--- a/prism-core/src/main/java/io/avaje/prism/internal/ServiceWriter.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/ServiceWriter.java
@@ -78,8 +78,7 @@ final class ServiceWriter {
 
     var module = getProjectModuleElement();
     if (module != null && !module.isUnnamed()) {
-      final Set<String> missingServices =
-          services.stream().map(ProcessorUtils::shortType).collect(toSet());
+      final Set<String> missingServices = services.stream().map(Util::shortName).collect(toSet());
 
       try (var reader = getModuleInfoReader(); ) {
 


### PR DESCRIPTION
now will issue a warning if people directly `requires io.avaje.prism` and fail compilation if the processor is not registered in the module-info.