### PR TITLE
Remove `provides` Module Validation Logic

### DIFF
--- a/prism-core/pom.xml
+++ b/prism-core/pom.xml
@@ -16,7 +16,7 @@
 	<dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
-      <version>1.5</version>
+      <version>1.7</version>
     </dependency>
   </dependencies>
 </project>

--- a/prism-core/pom.xml
+++ b/prism-core/pom.xml
@@ -16,7 +16,7 @@
 	<dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
-      <version>1.4</version>
+      <version>1.5</version>
       <optional>true</optional>
       <scope>provided</scope>
     </dependency>

--- a/prism-core/pom.xml
+++ b/prism-core/pom.xml
@@ -17,8 +17,6 @@
       <groupId>io.avaje</groupId>
       <artifactId>avaje-spi-service</artifactId>
       <version>1.5</version>
-      <optional>true</optional>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/prism-core/src/main/java/io/avaje/prism/internal/ServiceWriter.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/ServiceWriter.java
@@ -7,13 +7,9 @@ import static io.avaje.prism.internal.APContext.logError;
 import static io.avaje.prism.internal.APContext.logNote;
 import static io.avaje.prism.internal.APContext.logWarn;
 
-import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -34,27 +30,8 @@ final class ServiceWriter {
   static void write() {
 
     if (services.isEmpty()) return;
-
     // Read the existing service files
     final Filer filer = filer();
-    try (final var f =
-            filer
-                .getResource(StandardLocation.CLASS_OUTPUT, "", "META-INF/services/" + PROCESSOR)
-                .openInputStream();
-        final BufferedReader r =
-            new BufferedReader(new InputStreamReader(f, StandardCharsets.UTF_8)); ) {
-
-      String line;
-      while ((line = r.readLine()) != null) services.add(line);
-    } catch (final FileNotFoundException | java.nio.file.NoSuchFileException x) {
-      // missing and thus not created yet
-    } catch (final IOException x) {
-      logError(
-          "Failed to load existing service definition file. SPI: "
-              + PROCESSOR
-              + " exception: "
-              + x);
-    }
     try {
       logNote("Writing META-INF/services/%s", PROCESSOR);
       final FileObject f =
@@ -89,7 +66,6 @@ final class ServiceWriter {
             if (line.contains("io.avaje.prism.core")) {
               logWarn(module, "io.avaje.prism.core should be not be used directly");
             }
-            continue;
           }
         }
 

--- a/prism-core/src/main/java/module-info.java
+++ b/prism-core/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 module io.avaje.prism.core {
 
   requires java.compiler;
-  requires static io.avaje.spi;
+  requires static transitive io.avaje.spi;
   provides javax.annotation.processing.Processor with io.avaje.prism.internal.PrismGenerator;
 
 }


### PR DESCRIPTION
- makes avaje-spi-service a transitive dependency
- now relies on avaje-spi-service to validate module-info

relies on https://github.com/avaje/avaje-spi-service/pull/19