### PR TITLE
Reproducible Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Maven version
         run: mvn --version
       - name: Build with Maven
-        run: mvn clean install && mvn clean verify artifact:compare
+        run: mvn clean install && mvn clean package -DskipTests artifact:compare

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Maven version
         run: mvn --version
       - name: Build with Maven
-        run: mvn clean test
+        run: mvn clean install && mvn clean verify artifact:compare

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
 	</scm>
 
 	<properties>
+    <project.build.outputTimestamp>2024-10-25T04:21:12Z</project.build.outputTimestamp>
 	  <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
 	</properties>
 


### PR DESCRIPTION
I couldn't help but notice the change was reverted. Is there a particular reason why? was there an issue with the release maven plugin or are there other reservations that I can assuage?

There are a [multitude of libraries ](https://github.com/jvm-repo-rebuild/reproducible-central?tab=readme-ov-file#rebuild-detailed-results) that have the same configuration.