### PR TITLE
Fix Gradle Resource Detection for Test Compilation

### DIFF
--- a/prism-core/src/main/java/io/avaje/prism/internal/APContextWriter.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/APContextWriter.java
@@ -448,6 +448,7 @@ public class APContextWriter {
             + "            .toString()\n"
             + "            .replaceFirst(id, \"\")\n"
             + "            .replaceFirst(\"/classes/java/main\", \"\")\n"
+            + "            .replaceFirst(\"/classes/java/test\", \"\")\n"
             + "            .replaceFirst(\"/classes\", \"\");\n"
             + "    var updatedPath = Path.of(URI.create(uri));\n"
             + "    if (path.contains(\"/\")) {\n"


### PR DESCRIPTION
Currently during test compilation, the getBuildResourceMethod cannot find the build folder 

## Checklist before merge

Have these changes been tested with the below to confirm no negative interactions?
- [x] avaje-inject
- [x] avaje-jsonb
- [x] avaje-validator
- [x] avaje-spi-service
