### PR TITLE
Only validate services in the same module

### DIFF
--- a/prism-core/src/main/java/io/avaje/prism/internal/ModuleInfoReaderWriter.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/ModuleInfoReaderWriter.java
@@ -1,7 +1,6 @@
 package io.avaje.prism.internal;
 
 import java.io.PrintWriter;
-import java.util.regex.Pattern;
 
 public class ModuleInfoReaderWriter {
   private ModuleInfoReaderWriter() {}
@@ -212,7 +211,7 @@ public class ModuleInfoReaderWriter {
             + "   * @param providesType the provides directive to check\n"
             + "   * @param implementations the implementations to verify the presence of\n"
             + "   */\n"
-            + "  public void validateServices(String providesType, Collection<String> implementations) {\n"
+            + "    public void validateServices(String providesType, Collection<String> implementations) {\n"
             + "    if (buildPluginAvailable() || moduleElement.isUnnamed() || APContext.isTestCompilation()) {\n"
             + "      return;\n"
             + "    }\n"
@@ -232,7 +231,7 @@ public class ModuleInfoReaderWriter {
             + "    } catch (Exception e) {\n"
             + "      // not a critical error\n"
             + "    }\n"
-            + "    final var missingImpls = implSet.stream().map(this::replace$).collect(toSet());\n"
+            + "    final var missingImpls = implSet.stream().map(this::replace$).filter(this::isSameModule).collect(toSet());\n"
             + "\n"
             + "    provides()\n"
             + "        .forEach(\n"
@@ -253,6 +252,15 @@ public class ModuleInfoReaderWriter {
             + "\n"
             + "      APContext.logError(moduleElement, \"Missing `provides %s with %s;`\", providesType, message);\n"
             + "    }\n"
+            + "  }\n"
+            + "\n"
+            + "  private boolean isSameModule(String type) {\n"
+            + "    var element = APContext.typeElement(type);\n"
+            + "    return element != null\n"
+            + "        && APContext.elements()\n"
+            + "            .getModuleOf(element)\n"
+            + "            .getSimpleName()\n"
+            + "            .contentEquals(moduleElement.getSimpleName());\n"
             + "  }\n"
             + "\n"
             + "  private static boolean buildPluginAvailable() {\n"


### PR DESCRIPTION
Now the module info reader will not log an error if a service impl is not in the same module

## Checklist before merge

Have these changes been tested with the below to confirm no negative interactions?
- [x] avaje-inject
- [x] avaje-jsonb
- [x] avaje-validator
- [x] avaje-spi-service
