### PR TITLE
Fix JDK 25 module import errors

### DIFF
--- a/prism-core/src/main/java/io/avaje/prism/internal/APContextWriter.java
+++ b/prism-core/src/main/java/io/avaje/prism/internal/APContextWriter.java
@@ -9,7 +9,7 @@ public class APContextWriter {
 
   private static String compilerImports() {
 
-    if (jdkVersion() >= 25 || jdkVersion() >= 23 && APContext.previewEnabled()) {
+    if (jdkVersion() >= 23 && APContext.previewEnabled()) {
       return "import module java.base;\n" + "import module java.compiler;\n";
     }
 


### PR DESCRIPTION
It's not immediately apparent that module imports will be GA in JDK 25.
